### PR TITLE
Create and delete component endpoint

### DIFF
--- a/rest/client.go
+++ b/rest/client.go
@@ -19,6 +19,7 @@ type GetComponentsFilter struct {
 type Client interface {
 	GetComponent(context.Context, uuid.UUID) (models.Component, error)
 	GetComponentsByAsset(context.Context, uuid.UUID, GetComponentsFilter) ([]models.Component, error)
+	CreateComponent(context.Context, models.Component) (models.Component, error)
 	DeleteComponent(context.Context, uuid.UUID) error
 
 	GetComponentRelations(context.Context, uuid.UUID) ([]models.Relation, error)
@@ -70,6 +71,19 @@ func (c *client) GetComponentsByAsset(ctx context.Context, id uuid.UUID, filter 
 	}
 
 	return response.Components, nil
+}
+
+func (c *client) CreateComponent(ctx context.Context, component models.Component) (models.Component, error) {
+	request := rest.Post("/components").
+		WithJSONPayload(component).
+		SetHeader("Accept", "application/json")
+
+	var response models.Component
+	if err := c.DoAndUnmarshal(ctx, request, &response); err != nil {
+		return models.Component{}, err
+	}
+
+	return response, nil
 }
 
 func (c *client) DeleteComponent(ctx context.Context, id uuid.UUID) error {

--- a/rest/client.go
+++ b/rest/client.go
@@ -19,6 +19,7 @@ type GetComponentsFilter struct {
 type Client interface {
 	GetComponent(context.Context, uuid.UUID) (models.Component, error)
 	GetComponentsByAsset(context.Context, uuid.UUID, GetComponentsFilter) ([]models.Component, error)
+	DeleteComponent(context.Context, uuid.UUID) error
 
 	GetComponentRelations(context.Context, uuid.UUID) ([]models.Relation, error)
 	GetRelatedComponents(context.Context, models.Relation) ([]models.RelatedComponent, error)
@@ -69,6 +70,18 @@ func (c *client) GetComponentsByAsset(ctx context.Context, id uuid.UUID, filter 
 	}
 
 	return response.Components, nil
+}
+
+func (c *client) DeleteComponent(ctx context.Context, id uuid.UUID) error {
+	request := rest.Delete("components/{component}").
+		Assign("component", id).
+		SetHeader("Accept", "application/json")
+
+	if _, err := c.Do(ctx, request); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (c *client) GetComponentRelations(ctx context.Context, id uuid.UUID) ([]models.Relation, error) {

--- a/rest/mock/client.go
+++ b/rest/mock/client.go
@@ -31,6 +31,11 @@ func (c *AssetComponentsMock) GetComponentsByAsset(ctx context.Context, id uuid.
 	return args.Get(0).([]models.Component), args.Error(1)
 }
 
+func (c *AssetComponentsMock) CreateComponent(ctx context.Context, component models.Component) (models.Component, error) {
+	args := c.Called(ctx, component)
+	return args.Get(0).(models.Component), args.Error(1)
+}
+
 func (c *AssetComponentsMock) DeleteComponent(ctx context.Context, id uuid.UUID) error {
 	args := c.Called(ctx, id)
 	return args.Error(0)

--- a/rest/mock/client.go
+++ b/rest/mock/client.go
@@ -31,6 +31,11 @@ func (c *AssetComponentsMock) GetComponentsByAsset(ctx context.Context, id uuid.
 	return args.Get(0).([]models.Component), args.Error(1)
 }
 
+func (c *AssetComponentsMock) DeleteComponent(ctx context.Context, id uuid.UUID) error {
+	args := c.Called(ctx, id)
+	return args.Error(0)
+}
+
 func (c *AssetComponentsMock) GetComponentRelations(ctx context.Context, id uuid.UUID) ([]models.Relation, error) {
 	args := c.Called(ctx, id)
 	return args.Get(0).([]models.Relation), args.Error(1)


### PR DESCRIPTION
Add the create and the delete component endpoints. This change will enable users to create new components, and delete components by their identifier.